### PR TITLE
Add release-branch CI config for 1.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds the `releaseBranch:` block to `.github/workflows/enonic-gradle.yml` so the build-and-publish action recognizes both `master` and `1.x` as release branches
- Counterpart to the XP 8 upgrade PR on `master`; this branch holds the XP 7 maintenance line at `xpVersion=7.0.0`, `version=1.0.2-SNAPSHOT`

## Test plan
- [ ] CI Gradle Build green on push to this branch