### PR TITLE
Upgrade to XP 8

### DIFF
--- a/.github/workflows/enonic-docgen.yml
+++ b/.github/workflows/enonic-docgen.yml
@@ -1,0 +1,19 @@
+name: Generate Documentation
+
+on:
+  push:
+    branches:
+      - "master"
+      - "1.x"
+    paths:
+      - 'docs/**'
+  workflow_dispatch:
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: enonic/release-tools/generate-docs@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          webhook-secret: ${{ secrets.DEVELOPER_PORTAL_WEBHOOK_SECRET }}

--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'jacoco'
     id 'maven-publish'
     id 'com.enonic.defaults' version '2.1.6'
-    id 'com.enonic.xp.base' version '3.6.2'
+    id 'com.enonic.xp.base'
 }
 
 repositories {
@@ -12,14 +12,19 @@ repositories {
 }
 
 dependencies {
-    compileOnly "com.enonic.xp:script-api:${xpVersion}"
+    compileOnly xplibs.api.script
     implementation 'org.jdbi:jdbi:2.78'
     implementation 'com.zaxxer:HikariCP:7.0.2'
 
     testImplementation 'com.h2database:h2:2.4.240'
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.11.4'
     testImplementation 'org.mockito:mockito-core:5.23.0'
     testImplementation "com.enonic.xp:testing:${xpVersion}"
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+test {
+    useJUnitPlatform()
 }
 
 jacocoTestReport {
@@ -30,4 +35,3 @@ jacocoTestReport {
 }
 
 check.dependsOn jacocoTestReport
-

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,0 +1,6 @@
+{
+  "versions": [
+    { "label": "stable", "checkout": "1.x", "latest": true },
+    { "label": "next", "checkout": "master" }
+  ]
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group = com.enonic.lib
 projectName = lib-sql
-xpVersion=7.0.0
-version=1.0.2-SNAPSHOT
+xpVersion=8.0.0-B4
+version=2.0.0-SNAPSHOT

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,5 @@
+plugins {
+    id 'com.enonic.xp.settings' version '4.0.0-B1'
+}
+
 rootProject.name = projectName


### PR DESCRIPTION
## Summary
- Bumps `xpVersion` 7.0.0 → 8.0.0-B4 and `version` 1.0.2-SNAPSHOT → 2.0.0-SNAPSHOT
- Reorganizes the build around the XP 8 `com.enonic.xp.settings` 4.0.0-B1 plugin (drops the `com.enonic.xp.base` version pin, switches `com.enonic.xp:script-api` to the `xplibs.api.script` catalog alias)
- Migrates tests from JUnit 4 to JUnit 5 (XP 8's `ScriptRunnerSupport` is Jupiter-based) with `useJUnitPlatform()` and the explicitly-required `junit-platform-launcher` (Gradle 9 no longer auto-resolves it)
- Gradle wrapper 8.1 → 9.4.1 (settings plugin 4.x requires Gradle 9+)
- Adds the `releaseBranch:` block to `enonic-gradle.yml`, introduces `enonic-docgen.yml`, and seeds `docs/versions.json` declaring `1.x` as stable / `master` as next

The XP 7 maintenance line lives on the new `1.x` branch at `xpVersion=7.0.0`, `version=1.0.2-SNAPSHOT`.

## Test plan
- [x] `./gradlew clean build` green locally on Java 25 + Gradle 9.4.1 (4 JS tests pass via `SqlScriptLibTest`)
- [ ] CI Gradle Build green