### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,12 +13,12 @@ repositories {
 
 dependencies {
     compileOnly xplibs.api.script
-    implementation 'org.jdbi:jdbi:2.78'
-    implementation 'com.zaxxer:HikariCP:7.0.2'
+    implementation libs.jdbi
+    implementation libs.hikaricp
 
-    testImplementation 'com.h2database:h2:2.4.240'
-    testImplementation 'org.junit.jupiter:junit-jupiter:6.0.3'
-    testImplementation 'org.mockito:mockito-core:5.23.0'
+    testImplementation libs.h2
+    testImplementation libs.junit.jupiter
+    testImplementation libs.mockito.core
     testImplementation "com.enonic.xp:testing:${xpVersion}"
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,13 @@
+[versions]
+h2 = "2.4.240"
+hikaricp = "7.0.2"
+jdbi = "2.78"
+junit = "6.0.3"
+mockito = "5.23.0"
+
+[libraries]
+h2 = { module = "com.h2database:h2", version.ref = "h2" }
+hikaricp = { module = "com.zaxxer:HikariCP", version.ref = "hikaricp" }
+jdbi = { module = "org.jdbi:jdbi", version.ref = "jdbi" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }


### PR DESCRIPTION
## Summary

Migrates the five inline-versioned deps in `build.gradle` into a new `gradle/libs.versions.toml`. Pin-for-pin — no version bumps. `runtimeClasspath` and `testRuntimeClasspath` resolutions are identical before and after.

## Conventions

Matching the dominant style in neighbouring repos (e.g. `lib-mustache`):

- Hyphen-separated lowercase keys
- `[versions]` and `[libraries]` sorted alphabetically
- `xpVersion` stays in `gradle.properties` (`com.enonic.xp:testing:${xpVersion}` is left as-is)
- `xplibs.*` accessor pattern untouched

## Catalog

```toml
[versions]
h2 = "2.4.240"
hikaricp = "7.0.2"
jdbi = "2.78"
junit = "6.0.3"
mockito = "5.23.0"

[libraries]
h2 = { module = "com.h2database:h2", version.ref = "h2" }
hikaricp = { module = "com.zaxxer:HikariCP", version.ref = "hikaricp" }
jdbi = { module = "org.jdbi:jdbi", version.ref = "jdbi" }
junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
```

`testRuntimeOnly 'org.junit.platform:junit-platform-launcher'` already had no explicit version, so it was left in place (the migration is scoped to lines with explicit version strings).

## Test plan

- [x] `./gradlew build --refresh-dependencies` green locally
- [x] `./gradlew dependencies --configuration runtimeClasspath` matches pre-migration output
- [x] `./gradlew dependencies --configuration testRuntimeClasspath` matches pre-migration output
- [x] Unit tests pass (4/4)