### PR TITLE
Add @enonic-types/lib-sql types package #150

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -2,6 +2,10 @@ name: Gradle Build
 
 on: [ push ]
 
+permissions:
+  id-token: write  # Required for npm OIDC / trusted publishing
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,6 +17,7 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          npmPublish: true
           releaseBranch: |
             master
             1.x

--- a/build.gradle
+++ b/build.gradle
@@ -35,3 +35,15 @@ jacocoTestReport {
 }
 
 check.dependsOn jacocoTestReport
+
+// Assemble the @enonic-types/lib-sql npm package (published on release by the CI npmPublish step).
+tasks.register('assembleTypes', Copy) {
+    from 'types'
+    into layout.buildDirectory.dir('types')
+    filesMatching('package.json') {
+        filter { line ->
+            line.replaceAll(/"version":\s*"[^"]*"/, "\"version\": \"${project.version}\"")
+        }
+    }
+}
+jar.dependsOn assembleTypes

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,97 @@
+declare module "/lib/sql" {
+    export interface ConnectParams {
+        /**
+         * JDBC connection URL (e.g. `jdbc:h2:file:./build/tmp/data/db`).
+         */
+        url: string;
+        /**
+         * Fully-qualified JDBC driver class name (e.g. `org.h2.Driver`).
+         */
+        driver: string;
+        /**
+         * Database user.
+         */
+        user?: string;
+        /**
+         * Database password.
+         */
+        password?: string;
+        /**
+         * Maximum number of connections in the pool. Defaults to `10`.
+         */
+        maxPoolSize?: number;
+        /**
+         * Minimum number of idle connections kept in the pool. Defaults to `0`.
+         */
+        minPoolSize?: number;
+        /**
+         * Pool name used for logging and monitoring.
+         */
+        poolName?: string;
+    }
+
+    export interface QueryResult {
+        /**
+         * Number of rows returned.
+         */
+        count: number;
+        /**
+         * The result rows, each row keyed by column name.
+         */
+        result: Record<string, unknown>[];
+    }
+
+    export interface Handle {
+        /**
+         * Executes a `SELECT` query and returns all matching rows.
+         *
+         * @param sql SQL query to execute.
+         * @param limit Optional maximum number of rows to return.
+         */
+        query(sql: string, limit?: number | null): QueryResult;
+
+        /**
+         * Executes a `SELECT` query and returns the first matching row, or `null` if the result set is empty.
+         *
+         * @param sql SQL query to execute.
+         */
+        queryFirst(sql: string): Record<string, unknown> | null;
+
+        /**
+         * Executes an `INSERT` statement.
+         *
+         * @param sql SQL statement to execute.
+         * @returns The number of rows affected.
+         */
+        insert(sql: string): number;
+
+        /**
+         * Executes an `UPDATE` statement.
+         *
+         * @param sql SQL statement to execute.
+         * @returns The number of rows affected.
+         */
+        update(sql: string): number;
+
+        /**
+         * Executes a statement that does not return a result (e.g. `CREATE TABLE`, `DROP TABLE`).
+         *
+         * @param sql SQL statement to execute.
+         */
+        execute(sql: string): void;
+    }
+
+    /**
+     * Opens a connection to a SQL database and returns a handle for issuing queries and statements.
+     *
+     * @param params Connection parameters.
+     */
+    export function connect(params: ConnectParams): Handle;
+
+    /**
+     * Disposes of all open connections created by this library within the current application.
+     */
+    export function dispose(): void;
+}
+
+export {};

--- a/types/package.json
+++ b/types/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@enonic-types/lib-sql",
+  "version": "0.0.0",
+  "description": "Type definitions for the Enonic XP SQL library",
+  "types": "index.d.ts",
+  "files": [
+    "*"
+  ],
+  "keywords": [
+    "enonic",
+    "enonic-xp",
+    "lib-sql",
+    "sql",
+    "jdbc",
+    "types",
+    "typescript"
+  ],
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/enonic/lib-sql#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/enonic/lib-sql.git"
+  },
+  "bugs": {
+    "url": "https://github.com/enonic/lib-sql/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@enonic-types/core": "^8.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a published TypeScript types package (`@enonic-types/lib-sql`) so consumers of `/lib/sql` get typed access instead of hand-maintaining local declarations. Mirrors the scaffolding introduced by [enonic/lib-mustache#66](https://github.com/enonic/lib-mustache/pull/66).
- `types/index.d.ts` — ambient `declare module "/lib/sql"` covering `ConnectParams`, `QueryResult`, `Handle`, `connect`, and `dispose`.
- `types/package.json` — `@enonic-types/lib-sql`, `types: index.d.ts`, `publishConfig.access: public`, `dependencies: { "@enonic-types/core": "^8.0.0" }`, `version: 0.0.0` (substituted at build).
- `build.gradle` — `assembleTypes` Copy task writes to `build/types/` with `project.version` substituted; `jar.dependsOn assembleTypes` so it's always in sync with the jar.
- `.github/workflows/enonic-gradle.yml` — adds `npmPublish: true` on the build-and-publish step plus the `id-token: write` / `contents: write` permissions needed for npm OIDC trusted publishing. Depends on [enonic/release-tools#71](https://github.com/enonic/release-tools/pull/71) (merged).

## Verification
- Signatures verified against `src/main/resources/lib/sql.js` and the underlying beans (`SqlHandle`, `SqlHandleFactory`, `SqlSource`).
- Local `./gradlew build` green; `build/types/{index.d.ts,package.json}` produced with `2.1.0-SNAPSHOT` substituted for `0.0.0`.
- Compiled `index.d.ts` against a mock consumer with `strict: true` + `@ts-expect-error` for missing `url`, unknown properties, and mistyped arguments — all rejected as expected.

Closes #150

## Test plan
- [x] `./gradlew build` succeeds
- [x] `build/types/package.json` version substitution works
- [x] `index.d.ts` type-checks a valid consumer AND flags invalid usage under strict TS
- [ ] CI green on the PR branch
- [ ] First publish of the brand-new `@enonic-types/lib-sql` may need npm trusted-publisher setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)